### PR TITLE
API: increase restrictions

### DIFF
--- a/Qora/src/api/ATResource.java
+++ b/Qora/src/api/ATResource.java
@@ -156,7 +156,9 @@ public class ATResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_INVALID_SENDER);
 			}
-				
+
+			APIUtils.askAPICallAllowed("POST at "+ x, request);
+
 			//CHECK IF WALLET EXISTS
 			if(!Controller.getInstance().doesWalletExists())
 			{
@@ -168,9 +170,7 @@ public class ATResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-			
-			APIUtils.askAPICallAllowed("POST at "+ x, request);
-			
+
 			//GET ACCOUNT
 			PrivateKeyAccount account = Controller.getInstance().getPrivateKeyAccountByAddress(creator);				
 			if(account == null)

--- a/Qora/src/api/AddressesResource.java
+++ b/Qora/src/api/AddressesResource.java
@@ -41,6 +41,8 @@ public class AddressesResource {
 	@SuppressWarnings("unchecked")
 	@GET
 	public String getAddresses() {
+		APIUtils.askAPICallAllowed("GET addresses", request);
+
 		// CHECK IF WALLET EXISTS
 		if (!Controller.getInstance().doesWalletExists()) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -70,6 +72,8 @@ public class AddressesResource {
 	@GET
 	@Path("/seed/{address}")
 	public String getSeed(@PathParam("address") String address) {
+		APIUtils.askAPICallAllowed("GET addresses/seed/" + address+ "\nWARNING, your seed will be revealed to the caller!", request);
+
 		// CHECK IF WALLET EXISTS
 		if (!Controller.getInstance().doesWalletExists()) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -82,8 +86,6 @@ public class AddressesResource {
 					ApiErrorFactory.ERROR_WALLET_LOCKED);
 		}
 		
-		APIUtils.askAPICallAllowed("GET addresses/seed/" + address+ "\nWARNING, your seed will be revealed to the caller!", request);
-
 		// CHECK IF VALID ADDRESS
 		if (!Crypto.getInstance().isValidAddress(address)) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -104,6 +106,8 @@ public class AddressesResource {
 	@GET
 	@Path("/new")
 	public String generateNewAccount() {
+		APIUtils.askAPICallAllowed("GET addresses/new", request);
+
 		// CHECK IF WALLET EXISTS
 		if (!Controller.getInstance().doesWalletExists()) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -115,8 +119,6 @@ public class AddressesResource {
 			throw ApiErrorFactory.getInstance().createError(
 					ApiErrorFactory.ERROR_WALLET_LOCKED);
 		}
-		
-		APIUtils.askAPICallAllowed("GET addresses/new", request);
 
 		return Controller.getInstance().generateNewAccount();
 	}
@@ -126,6 +128,8 @@ public class AddressesResource {
 	public String createNewAddress(String x) {
 		// CHECK IF CONTENT IS EMPTY
 		if (x.isEmpty()) {
+			APIUtils.askAPICallAllowed("POST addresses seed\nGenerates a new account", request);
+
 			// CHECK IF WALLET EXISTS
 			if (!Controller.getInstance().doesWalletExists()) {
 				throw ApiErrorFactory.getInstance().createError(
@@ -137,13 +141,11 @@ public class AddressesResource {
 				throw ApiErrorFactory.getInstance().createError(
 						ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-			
-			APIUtils.askAPICallAllowed("POST addresses seed\nGenerates a new account", request);
-			
-
 
 			return Controller.getInstance().generateNewAccount();
 		} else {
+			APIUtils.askAPICallAllowed("POST addresses seed\n " + x, request);
+
 			String seed = x;
 
 			// CHECK IF WALLET EXISTS
@@ -158,8 +160,6 @@ public class AddressesResource {
 						ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
 			
-			APIUtils.askAPICallAllowed("POST addresses seed\n " + x, request);
-
 			// DECODE SEED
 			byte[] seedBytes;
 			try {
@@ -184,6 +184,8 @@ public class AddressesResource {
 	@DELETE
 	@Path("/{address}")
 	public String deleteAddress(@PathParam("address") String address) {
+		APIUtils.askAPICallAllowed("DELETE addresses/" + address, request );
+
 		// CHECK IF WALLET EXISTS
 		if (!Controller.getInstance().doesWalletExists()) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -196,8 +198,6 @@ public class AddressesResource {
 					ApiErrorFactory.ERROR_WALLET_LOCKED);
 		}
 		
-		APIUtils.askAPICallAllowed("DELETE addresses/" + address, request );
-
 		// CHECK IF VALID ADDRESS
 		if (!Crypto.getInstance().isValidAddress(address)) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -302,6 +302,8 @@ public class AddressesResource {
 	@POST
 	@Path("sign/{address}")
 	public String sign(String x, @PathParam("address") String address) {
+		APIUtils.askAPICallAllowed("POST addresses/sign/"+ address, request);
+
 		// CHECK IF WALLET EXISTS
 		if (!Controller.getInstance().doesWalletExists()) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -314,8 +316,6 @@ public class AddressesResource {
 					ApiErrorFactory.ERROR_WALLET_LOCKED);
 		}
 		
-		APIUtils.askAPICallAllowed("POST addresses/sign/"+ address, request);
-
 		// CHECK IF VALID ADDRESS
 		if (!Crypto.getInstance().isValidAddress(address)) {
 			throw ApiErrorFactory.getInstance().createError(

--- a/Qora/src/api/ArbitraryTransactionsResource.java
+++ b/Qora/src/api/ArbitraryTransactionsResource.java
@@ -35,6 +35,8 @@ public class ArbitraryTransactionsResource
 	{
 		try
 		{
+			APIUtils.askAPICallAllowed("POST arbitrarytransactions\n" + x, request );
+
 			//READ JSON
 			JSONObject jsonObject = (JSONObject) JSONValue.parse(x);
 			int service = ((Long) jsonObject.get("service")).intValue();
@@ -85,8 +87,6 @@ public class ArbitraryTransactionsResource
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
 				
-			APIUtils.askAPICallAllowed("POST arbitrarytransactions\n" + x, request );
-			
 			//GET ACCOUNT
 			PrivateKeyAccount account = Controller.getInstance().getPrivateKeyAccountByAddress(creator);				
 			if(account == null)

--- a/Qora/src/api/BlocksResource.java
+++ b/Qora/src/api/BlocksResource.java
@@ -2,10 +2,12 @@ package api;
 
 import java.util.List;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import org.json.simple.JSONArray;
@@ -16,6 +18,7 @@ import qora.block.Block;
 import qora.block.GenesisBlock;
 import qora.crypto.Base58;
 import qora.crypto.Crypto;
+import utils.APIUtils;
 import utils.Pair;
 import controller.Controller;
 import database.DBSet;
@@ -24,6 +27,9 @@ import database.DBSet;
 @Produces(MediaType.APPLICATION_JSON)
 public class BlocksResource 
 {
+	@Context
+	HttpServletRequest request;
+
 	@SuppressWarnings("unchecked")
 	@GET
 	public String getBlocks()
@@ -50,18 +56,21 @@ public class BlocksResource
 	@Path("/address/{address}")	
 	public String getBlocks(@PathParam("address") String address)
 	{
-		//CHECK IF WALLET EXISTS
-		if(!Controller.getInstance().doesWalletExists())
-		{
-			throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_NO_EXISTS);
-		}
-				
+
 		//CHECK ADDRESS
 		if(!Crypto.getInstance().isValidAddress(address))
 		{
 			throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_INVALID_ADDRESS);
 		}
-				
+
+		APIUtils.askAPICallAllowed("GET blocks/address/" + address, request);
+
+		//CHECK IF WALLET EXISTS
+		if(!Controller.getInstance().doesWalletExists())
+		{
+			throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_NO_EXISTS);
+		}
+
 		//CHECK ACCOUNT IN WALLET
 		Account account = Controller.getInstance().getAccountByAddress(address);	
 		if(account == null)

--- a/Qora/src/api/BlocksResource.java
+++ b/Qora/src/api/BlocksResource.java
@@ -34,6 +34,8 @@ public class BlocksResource
 	@GET
 	public String getBlocks()
 	{
+		APIUtils.askAPICallAllowed("GET blocks", request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{

--- a/Qora/src/api/BlogPostResource.java
+++ b/Qora/src/api/BlogPostResource.java
@@ -71,6 +71,17 @@ public class BlogPostResource {
 						ApiErrorFactory.ERROR_INVALID_FEE);
 			}
 
+			// CHECK ADDRESS
+			if (!Crypto.getInstance().isValidAddress(creator)) {
+				throw ApiErrorFactory.getInstance().createError(
+					ApiErrorFactory.ERROR_INVALID_ADDRESS);
+			}
+
+			isPostAllowed(blogname);
+
+			APIUtils.askAPICallAllowed("POST blogpost/" + blogname + "\n" + x,
+				request);
+
 			// CHECK IF WALLET EXISTS
 			if (!Controller.getInstance().doesWalletExists()) {
 				throw ApiErrorFactory.getInstance().createError(
@@ -96,12 +107,6 @@ public class BlogPostResource {
 				
 			}
 
-			// CHECK ADDRESS
-			if (!Crypto.getInstance().isValidAddress(creator)) {
-				throw ApiErrorFactory.getInstance().createError(
-						ApiErrorFactory.ERROR_INVALID_ADDRESS);
-			}
-
 			// CHECK ACCOUNT IN WALLET
 
 			if (Controller.getInstance().getAccountByAddress(creator) == null) {
@@ -116,11 +121,6 @@ public class BlogPostResource {
 				throw ApiErrorFactory.getInstance().createError(
 						ApiErrorFactory.ERROR_INVALID_ADDRESS);
 			}
-
-			isPostAllowed(blogname);
-
-			APIUtils.askAPICallAllowed("POST blogpost/" + blogname + "\n" + x,
-					request);
 
 			JSONObject dataStructure = new JSONObject();
 

--- a/Qora/src/api/MessageResource.java
+++ b/Qora/src/api/MessageResource.java
@@ -104,6 +104,10 @@ public class MessageResource {
 						ApiErrorFactory.ERROR_INVALID_SENDER);
 			}
 
+			// check this up here to avoid leaking wallet information to remote user
+			// full check is later to prompt user with calculated fee
+			APIUtils.disallowRemote(request);
+
 			// CHECK IF WALLET EXISTS
 			if (!Controller.getInstance().doesWalletExists()) {
 				throw ApiErrorFactory.getInstance().createError(

--- a/Qora/src/api/NameSalesResource.java
+++ b/Qora/src/api/NameSalesResource.java
@@ -39,6 +39,8 @@ public class NameSalesResource
 	@GET
 	public String getNameSales()
 	{
+		APIUtils.askAPICallAllowed("GET namesales", request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{
@@ -61,6 +63,8 @@ public class NameSalesResource
 	@Path("/address/{address}")	
 	public String getNameSales(@PathParam("address") String address)
 	{
+		APIUtils.askAPICallAllowed("GET namesales/address/" + address, request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{
@@ -155,8 +159,10 @@ public class NameSalesResource
 			catch(Exception e)
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_INVALID_FEE);
-			}	
-				
+			}
+
+			APIUtils.askAPICallAllowed("POST namesales/" + nameName + "\n"+x, request);
+
 			//CHECK IF WALLET EXISTS
 			if(!Controller.getInstance().doesWalletExists())
 			{
@@ -168,9 +174,7 @@ public class NameSalesResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-			
-			APIUtils.askAPICallAllowed("POST namesales/" + nameName + "\n"+x, request);
-				
+
 			//GET NAME
 			Name name = Controller.getInstance().getName(nameName);
 			if(name == null)
@@ -267,7 +271,9 @@ public class NameSalesResource
 			}	
 			
 			NameSale nameSale = Controller.getInstance().getNameSale(nameName);
-			
+
+			APIUtils.askAPICallAllowed("DELETE namesales/"+nameName+"/"+ fee, request );
+
 			//CHECK IF WALLET EXISTS
 			if(!Controller.getInstance().doesWalletExists())
 			{
@@ -279,9 +285,7 @@ public class NameSalesResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-			
-			APIUtils.askAPICallAllowed("DELETE namesales/"+nameName+"/"+ fee, request );
-			
+
 			//CHECK IF NAME SALE EXISTS
 			if(nameSale == null)
 			{
@@ -375,8 +379,10 @@ public class NameSalesResource
 			catch(Exception e)
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_INVALID_FEE);
-			}	
-			
+			}
+
+			APIUtils.askAPICallAllowed("POST namesales/buy/" + nameName + "\n" + x, request);
+
 			//CHECK IF WALLET EXISTS
 			if(!Controller.getInstance().doesWalletExists())
 			{
@@ -388,9 +394,7 @@ public class NameSalesResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-			
-			APIUtils.askAPICallAllowed("POST namesales/buy/" + nameName + "\n" + x, request);
-			
+
 			NameSale nameSale = Controller.getInstance().getNameSale(nameName);
 			
 			//CHECK IF NAME SALE EXISTS

--- a/Qora/src/api/NameStorageResource.java
+++ b/Qora/src/api/NameStorageResource.java
@@ -125,6 +125,7 @@ public class NameStorageResource {
 	@Path("/update/{name}")
 	public String updateEntry(String x, @PathParam("name") String name) {
 		try {
+			APIUtils.disallowRemote(request);
 
 			// READ JSON
 			JSONObject jsonObject = (JSONObject) JSONValue.parse(x);

--- a/Qora/src/api/NamesResource.java
+++ b/Qora/src/api/NamesResource.java
@@ -39,6 +39,8 @@ public class NamesResource {
 	@SuppressWarnings("unchecked")
 	@GET
 	public String getNames() {
+		APIUtils.askAPICallAllowed("GET names", request);
+
 		// CHECK IF WALLET EXISTS
 		if (!Controller.getInstance().doesWalletExists()) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -59,6 +61,8 @@ public class NamesResource {
 	@GET
 	@Path("/address/{address}")
 	public String getNames(@PathParam("address") String address) {
+		APIUtils.askAPICallAllowed("GET names/address/" + address, request);
+
 		// CHECK IF WALLET EXISTS
 		if (!Controller.getInstance().doesWalletExists()) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -127,6 +131,8 @@ public class NamesResource {
 						ApiErrorFactory.ERROR_INVALID_ADDRESS);
 			}
 
+			APIUtils.askAPICallAllowed("POST names " + x, request);
+
 			// CHECK IF WALLET EXISTS
 			if (!Controller.getInstance().doesWalletExists()) {
 				throw ApiErrorFactory.getInstance().createError(
@@ -138,8 +144,6 @@ public class NamesResource {
 				throw ApiErrorFactory.getInstance().createError(
 						ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-
-			APIUtils.askAPICallAllowed("Post names " + x, request);
 
 			// GET ACCOUNT
 			PrivateKeyAccount account = Controller.getInstance()
@@ -227,6 +231,9 @@ public class NamesResource {
 						ApiErrorFactory.ERROR_INVALID_FEE);
 			}
 
+			APIUtils.askAPICallAllowed("DELETE names/key/" + nameName + "\n"
+				                           + x, request);
+
 			// CHECK IF WALLET EXISTS
 			if (!Controller.getInstance().doesWalletExists()) {
 				throw ApiErrorFactory.getInstance().createError(
@@ -255,9 +262,6 @@ public class NamesResource {
 				throw ApiErrorFactory.getInstance().createError(
 						ApiErrorFactory.ERROR_INVALID_NAME_OWNER);
 			}
-			
-			APIUtils.askAPICallAllowed("DELETE names/key/" + nameName + "\n"
-					+ x, request);
 
 			String oldValue = GZIP.webDecompress(name.getValue());
 			JSONObject resultJson = null;
@@ -359,6 +363,9 @@ public class NamesResource {
 						ApiErrorFactory.ERROR_INVALID_FEE);
 			}
 
+			APIUtils.askAPICallAllowed("POST names/key/" + nameName + "\n" + x,
+				request);
+
 			// CHECK IF WALLET EXISTS
 			if (!Controller.getInstance().doesWalletExists()) {
 				throw ApiErrorFactory.getInstance().createError(
@@ -370,9 +377,6 @@ public class NamesResource {
 				throw ApiErrorFactory.getInstance().createError(
 						ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-
-			APIUtils.askAPICallAllowed("POST names/key/" + nameName + "\n" + x,
-					request);
 
 			// GET NAME
 			Name name = Controller.getInstance().getName(nameName);
@@ -463,6 +467,9 @@ public class NamesResource {
 						ApiErrorFactory.ERROR_INVALID_ADDRESS);
 			}
 
+			APIUtils.askAPICallAllowed("POST names/" + nameName + "\n" + x,
+				request);
+
 			// CHECK IF WALLET EXISTS
 			if (!Controller.getInstance().doesWalletExists()) {
 				throw ApiErrorFactory.getInstance().createError(
@@ -474,9 +481,6 @@ public class NamesResource {
 				throw ApiErrorFactory.getInstance().createError(
 						ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-
-			APIUtils.askAPICallAllowed("POST names/" + nameName + "\n" + x,
-					request);
 
 			// GET NAME
 			Name name = Controller.getInstance().getName(nameName);

--- a/Qora/src/api/PollsResource.java
+++ b/Qora/src/api/PollsResource.java
@@ -35,7 +35,7 @@ public class PollsResource
 {
 	@Context
 	HttpServletRequest request;
-	
+
 	@POST
 	@Consumes(MediaType.WILDCARD)
 	public String createPoll(String x)
@@ -82,7 +82,9 @@ public class PollsResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_INVALID_ADDRESS);
 			}
-				
+
+			APIUtils.askAPICallAllowed("POST polls " + x, request);
+
 			//CHECK IF WALLET EXISTS
 			if(!Controller.getInstance().doesWalletExists())
 			{
@@ -94,9 +96,7 @@ public class PollsResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-			
-			APIUtils.askAPICallAllowed("Post polls " + x, request);
-				
+
 			//GET ACCOUNT
 			PrivateKeyAccount account = Controller.getInstance().getPrivateKeyAccountByAddress(creator);				
 			if(account == null)
@@ -209,7 +209,9 @@ public class PollsResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_INVALID_ADDRESS);
 			}
-				
+
+			APIUtils.askAPICallAllowed("POST polls/vote/" + name + "\n"+x, request);
+
 			//CHECK IF WALLET EXISTS
 			if(!Controller.getInstance().doesWalletExists())
 			{
@@ -221,9 +223,7 @@ public class PollsResource
 			{
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_LOCKED);
 			}
-			
-			APIUtils.askAPICallAllowed("POST polls/vote/" + name + "\n"+x, request);
-				
+
 			//GET ACCOUNT
 			PrivateKeyAccount account = Controller.getInstance().getPrivateKeyAccountByAddress(voter);				
 			if(account == null)
@@ -312,6 +312,8 @@ public class PollsResource
 	@GET
 	public String getPolls()
 	{
+		APIUtils.askAPICallAllowed("GET polls", request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{
@@ -334,6 +336,8 @@ public class PollsResource
 	@Path("/address/{address}")	
 	public String getPolls(@PathParam("address") String address)
 	{
+		APIUtils.askAPICallAllowed("GET polls/address/" + address, request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{

--- a/Qora/src/api/QoraResource.java
+++ b/Qora/src/api/QoraResource.java
@@ -1,20 +1,28 @@
 package api;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import controller.Controller;
+import utils.APIUtils;
 
 @Path("qora")
 @Produces(MediaType.APPLICATION_JSON)
 public class QoraResource 
 {
+	@Context
+	HttpServletRequest request;
+
 	@GET
 	@Path("/stop")
 	public String stop()
 	{
+		APIUtils.askAPICallAllowed("GET qora/stop", request);
+
 		//STOP
 		Controller.getInstance().stopAll();		
 		System.exit(0);

--- a/Qora/src/api/TransactionsResource.java
+++ b/Qora/src/api/TransactionsResource.java
@@ -5,11 +5,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 
 import org.json.simple.JSONArray;
@@ -23,11 +25,15 @@ import qora.block.Block;
 import qora.crypto.Base58;
 import qora.crypto.Crypto;
 import qora.transaction.Transaction;
+import utils.APIUtils;
 import utils.Pair;
 
 @Path("transactions")
 @Produces(MediaType.APPLICATION_JSON)
 public class TransactionsResource {
+
+	@Context
+	HttpServletRequest request;
 
 	@GET
 	public String getTransactions()
@@ -54,6 +60,8 @@ public class TransactionsResource {
 	@Path("limit/{limit}")
 	public String getTransactionsLimited(@PathParam("limit") int limit)
 	{
+		APIUtils.askAPICallAllowed("GET transactions/limit/" + limit, request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{
@@ -100,6 +108,8 @@ public class TransactionsResource {
 	@Path("address/{address}/limit/{limit}")
 	public String getTransactionsLimited(@PathParam("address") String address, @PathParam("limit") int limit)
 	{
+		APIUtils.askAPICallAllowed("GET transactions/address/" + address + "/limit/" + limit, request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{
@@ -209,18 +219,24 @@ public class TransactionsResource {
 			int blockLimit = -1;
 			try
 			{
-				 blockLimit = ((Long) jsonObject.get("blocklimit")).intValue();
+				blockLimit = ((Long) jsonObject.get("blocklimit")).intValue();
+
+				if (blockLimit > 16)
+				{
+					APIUtils.disallowRemote(request);
+				}
 			}
 			catch(NullPointerException e)
 			{
 				//OPTION DOES NOT EXIST
+				APIUtils.disallowRemote(request);
 			}
 			catch(ClassCastException e)
 			{
 				//JSON EXCEPTION
 				throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_JSON);
 			}
-			
+
 			//CHECK FOR TRANSACTIONLIMIT
 			int transactionLimit = -1;
 			try

--- a/Qora/src/api/WalletResource.java
+++ b/Qora/src/api/WalletResource.java
@@ -27,6 +27,8 @@ public class WalletResource {
 	@GET
 	public String getWallet()
 	{
+		APIUtils.askAPICallAllowed("GET wallet", request);
+
 		JSONObject jsonObject = new JSONObject();
 		
 		jsonObject.put("exists", Controller.getInstance().doesWalletExists());
@@ -39,7 +41,9 @@ public class WalletResource {
 	@Path("/seed")
 	public String getSeed()
 	{
-		
+
+		APIUtils.askAPICallAllowed("GET wallet/seed", request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{
@@ -51,9 +55,7 @@ public class WalletResource {
 		{
 			throw ApiErrorFactory.getInstance().createError(ApiErrorFactory.ERROR_WALLET_LOCKED);
 		}
-		
-		APIUtils.askAPICallAllowed("GET wallet/seed", request);
-				
+
 		byte[] seed = Controller.getInstance().exportSeed();
 		return Base58.encode(seed);
 	}
@@ -62,6 +64,8 @@ public class WalletResource {
 	@Path("/synchronize")
 	public String synchronize()
 	{
+		APIUtils.askAPICallAllowed("GET wallet/synchronize", request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{
@@ -76,6 +80,8 @@ public class WalletResource {
 	@Path("/lock")
 	public String lock()
 	{
+		APIUtils.askAPICallAllowed("GET wallet/lock", request);
+
 		//CHECK IF WALLET EXISTS
 		if(!Controller.getInstance().doesWalletExists())
 		{
@@ -91,6 +97,8 @@ public class WalletResource {
 	{
 		try
 		{
+			APIUtils.askAPICallAllowed("POST wallet/create " + x, request);
+
 			//READ JSON
 			JSONObject jsonObject = (JSONObject) JSONValue.parse(x);
 			boolean recover = (boolean) jsonObject.get("recover");
@@ -156,6 +164,8 @@ public class WalletResource {
 	@Consumes(MediaType.WILDCARD)	
 	public String unlock(String x)
 	{
+		APIUtils.askAPICallAllowed("POST wallet/unlock " + x, request);
+
 		String password = x;
 		
 		//CHECK IF WALLET EXISTS

--- a/Qora/src/utils/APIUtils.java
+++ b/Qora/src/utils/APIUtils.java
@@ -45,6 +45,8 @@ public class APIUtils {
 					ApiErrorFactory.ERROR_INVALID_SENDER);
 		}
 
+		APIUtils.askAPICallAllowed("POST payment\n" + x, request);
+
 		// CHECK IF WALLET EXISTS
 		if (!Controller.getInstance().doesWalletExists()) {
 			throw ApiErrorFactory.getInstance().createError(
@@ -64,8 +66,6 @@ public class APIUtils {
 			throw ApiErrorFactory.getInstance().createError(
 					ApiErrorFactory.ERROR_INVALID_SENDER);
 		}
-
-		APIUtils.askAPICallAllowed("POST payment\n" + x, request);
 
 		// SEND PAYMENT
 		Pair<Transaction, Integer> result = Controller.getInstance()
@@ -118,16 +118,20 @@ public class APIUtils {
 		}
 	}
 
+	public static void disallowRemote(HttpServletRequest request) throws WebApplicationException {
+		if (ServletUtils.isRemoteRequest(request)) {
+			throw ApiErrorFactory
+				      .getInstance()
+				      .createError(
+					      ApiErrorFactory.ERROR_WALLET_API_CALL_FORBIDDEN_BY_USER);
+		}
+	}
+
 	public static void askAPICallAllowed(final String messageToDisplay,
 			HttpServletRequest request) throws WebApplicationException {
 		// CHECK API CALL ALLOWED
 		try {
-			if (ServletUtils.isRemoteRequest(request)) {
-				throw ApiErrorFactory
-						.getInstance()
-						.createError(
-								ApiErrorFactory.ERROR_WALLET_API_CALL_FORBIDDEN_BY_USER);
-			}
+			disallowRemote(request);
 
 			if (Controller.getInstance().checkAPICallAllowed(messageToDisplay,
 					request) != JOptionPane.YES_OPTION) {


### PR DESCRIPTION
restrictions on json api are increased with an eye towards protecting against unauthorized remote usage

- askAPICallAllowed() calls are moved prior to wallet checks so that remote user cannot enumerate whether wallet is locked or unlocked
- when this is unreasonable, a new api utility function disallowRemote() is used to reject remote users prior to checking wallet
- checks added to functions which report addresses in wallet
- checks added to functions which were missing them (such as qora/stop which should not be remote usable)

I believe that askAPICallAllowed() is the proper call here, because a malicious website can trigger these calls locally as well as an incoming connection remotely.  The user should be prompted as well as remote calls prohibited.