### PR TITLE
Minor fixes to log4j: better log name, use unix carriage returns

### DIFF
--- a/Qora/.gitignore
+++ b/Qora/.gitignore
@@ -5,4 +5,4 @@
 /languages/
 settings.json
 peers.json
-/log.txt*
+/qora.log*

--- a/Qora/log4j2.properties
+++ b/Qora/log4j2.properties
@@ -1,7 +1,7 @@
 rootLogger.level = info
-# On Windows, this might be rewritten as:
+# On Windows this can be rewritten as:
 # property.filename = ${sys:user.home}\\AppData\\Roaming\\Qora\\log.txt
-property.filename = log.txt
+property.filename = qora.log
 
 rootLogger.appenderRef.console.ref = stdout
 rootLogger.appenderRef.rolling.ref = FILE


### PR DESCRIPTION
added some minor fixes; the file's endlines all had "^M" -- logfile names usually end with `.log`